### PR TITLE
bump required Ruby version to `2.6.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
       rexml
     diff-lcs (1.4.4)
     hashdiff (1.0.1)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
@@ -63,6 +65,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/tel_search.gemspec
+++ b/tel_search.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A ruby wrapper for the tel.search.ch/api endpoint"
   spec.homepage = "https://github.com/renuo/tel_search"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to 'https://mygemserver.com'"
 


### PR DESCRIPTION
Hey there 👋🏼 

This PR bumps the required Ruby version to `2.6.0` since the Gem is using endless ranges which were first introduced in Ruby 2.6