### PR TITLE
Disable fail-fast in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby


### PR DESCRIPTION
Otherwise it't a real pain to debug ruby version specific issues.